### PR TITLE
Dynamic blue termination time

### DIFF
--- a/modules/ecs-codedeploy/codedeploy.tf
+++ b/modules/ecs-codedeploy/codedeploy.tf
@@ -21,7 +21,7 @@ resource "aws_codedeploy_deployment_group" "codedeploy" {
 
     terminate_blue_instances_on_deployment_success {
       action                           = "TERMINATE"
-      termination_wait_time_in_minutes = 5
+      termination_wait_time_in_minutes = var.termination_wait_time_in_minutes
     }
   }
 

--- a/modules/ecs-codedeploy/vars.tf
+++ b/modules/ecs-codedeploy/vars.tf
@@ -41,3 +41,8 @@ variable "trigger_targets" {
   type    = list(string)
   default = []
 }
+
+variable "termination_wait_time_in_minutes" {
+  type    = number
+  default = 5
+}


### PR DESCRIPTION
Defaults to 5, configurable so that prod can have a longer one